### PR TITLE
printing loss, denominator fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ def train(X, Y, model, args):
 
             sum_loss += float(loss)
 
-        print("Epoch: {:4d}\tloss: {}".format(epoch, sum_loss / N))
+        print("Epoch: {:4d}\tloss: {}".format(epoch, sum_loss / (N / args.batchsize)))
 
 
 def visualize(X, Y, model):


### PR DESCRIPTION
#4 In the for loop code loops with range(0,N,args.batchsize) which loops N/args.batchsize times. Therefore sum_loss += float(loss) is ran N/args.batchsize times. But when printing the epoch loss, sum_loss is divided by only N which is in my opinion false. The commit in this PR contains what I think it should be divided with.